### PR TITLE
[SCRUM-56] 에러 및 로딩 대응 리팩토링

### DIFF
--- a/Projects/Feature/ErrorFeature/Sources/NetworkError/NetworkErrorCore.swift
+++ b/Projects/Feature/ErrorFeature/Sources/NetworkError/NetworkErrorCore.swift
@@ -28,6 +28,7 @@ public struct NetworkErrorCore {
   private func core(_ state: inout State, _ action: Action) -> EffectOf<Self> {
     switch action {
     case .tryAgain:
+      //TODO: 11.25 재시도 로직
       return .none
     }
   }

--- a/Projects/Feature/ErrorFeature/Sources/RequestError/RequestErrorCore.swift
+++ b/Projects/Feature/ErrorFeature/Sources/RequestError/RequestErrorCore.swift
@@ -35,8 +35,8 @@ public struct RequestErrorCore {
     case .moveToHome:
       return .none
     case .moveToCustomerService:
-      guard let feedbackURL = URL(string: "https://forms.gle/wEUPH9Tvxgua4hCZ9") else { return .none }
-      return .run { _ in await self.openURL(feedbackURL) }
+      guard let kakaoChannelURL = URL(string: "http://pf.kakao.com/_FvuAn") else { return .none }
+      return .run { _ in await self.openURL(kakaoChannelURL) }
     }
   }
 }

--- a/Projects/Feature/Feature/Sources/AppCore.swift
+++ b/Projects/Feature/Feature/Sources/AppCore.swift
@@ -161,7 +161,6 @@ public struct AppCore {
     case .networkError:
       return .none
 
-      // TODO: state 초기화 방법 변경 필요 + 온보딩 첫페이지로 돌아가면 온보딩 carousel 이미지 안뜸
     case .requestError(.presented(.moveToHome)):
       if state.onboarding != nil {
         state.onboarding = OnboardingCore.State()

--- a/Projects/Feature/Feature/Sources/AppView.swift
+++ b/Projects/Feature/Feature/Sources/AppView.swift
@@ -15,7 +15,6 @@ import OnboardingFeature
 import ErrorFeature
 
 import ComposableArchitecture
-import Lottie
 
 public struct AppView: View {
   @Bindable var store: StoreOf<AppCore>
@@ -46,23 +45,8 @@ public struct AppView: View {
     }
     .transition(.opacity)
     .animation(.easeInOut, value: store.home == nil)
-    .onLoad {
-      store.send(.onLoad)
-    }
     .fullScreenCover(isPresented: $store.isLoading) {
-      VStack {
-        Spacer()
-        ZStack {
-          RoundedRectangle(cornerRadius: Alias.BorderRadius.medium)
-            .foregroundStyle(Alias.Color.Background.inverse)
-            .opacity(Global.Opacity._90d)
-          LottieView(animation: AnimationAsset.lotiSpinner.animation)
-            .playing(loopMode: .loop)
-        }
-        .frame(width: 82, height: 82)
-        Spacer()
-      }
-      .presentationBackground(.clear)
+      LoadingView()
     }
     .fullScreenCover(
       item: $store.scope(
@@ -81,8 +65,11 @@ public struct AppView: View {
       NetworkErrorView(store: store)
     }
     .transaction(value: store.isLoading) { transaction in
-      // TODO: 11/24, LoadingView 분리 + fullscreen animation disable
+      // TODO: 11.25 로딩 이외 다른 fullScreen들도 disabled됨
       transaction.disablesAnimations = true
+    }
+    .onLoad {
+      store.send(.onLoad)
     }
   }
 }

--- a/Projects/Feature/Feature/Sources/Loading/LoadingView.swift
+++ b/Projects/Feature/Feature/Sources/Loading/LoadingView.swift
@@ -6,4 +6,26 @@
 //  Copyright © 2024 PomoNyang. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
+
+import DesignSystem
+
+import Lottie
+
+struct LoadingView: View {
+  var body: some View {
+    VStack {
+      Spacer()
+      ZStack {
+        RoundedRectangle(cornerRadius: Alias.BorderRadius.medium)
+          .foregroundStyle(Alias.Color.Background.inverse)
+          .opacity(Global.Opacity._90d)
+        LottieView(animation: AnimationAsset.lotiSpinner.animation)
+          .playing(loopMode: .loop)
+      }
+      .frame(width: 82, height: 82)
+      Spacer()
+    }
+    .presentationBackground(.clear)
+  }
+}

--- a/Projects/Feature/Feature/Sources/Loading/LoadingView.swift
+++ b/Projects/Feature/Feature/Sources/Loading/LoadingView.swift
@@ -1,0 +1,9 @@
+//
+//  LoadingView.swift
+//  Feature
+//
+//  Created by 김지현 on 11/25/24.
+//  Copyright © 2024 PomoNyang. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/OnboardingFeature/Sources/Onboarding/OnboardingView.swift
+++ b/Projects/Feature/OnboardingFeature/Sources/Onboarding/OnboardingView.swift
@@ -66,6 +66,10 @@ public struct OnboardingView: View {
     .background(Alias.Color.Background.primary)
     .setFrameMeasure(space: .global, identifier: backgroundFrame)
     .getFrameMeasure { value in
+      /* TODO: 11.25
+       Onboarding 재 초기화 시 FrameMeasure 관련 모디파이어를 안거침 . ,, 파악중
+       getFrameMeasure -> OnDisappear 시에도 거치는 이유는 ?
+      */
       guard let background = value[backgroundFrame] else { return }
       store.width = background.width
     }


### PR DESCRIPTION
## [SCRUM-56] 에러 및 로딩 대응 리팩토링

## 무엇에 관한 PR 인가요? 🙋
원래 목표
- [ ] 재시도 버튼 로직 구현 
- [ ] 로딩뷰 / 서버통신에러뷰 / 네트워크에러뷰 중 로딩뷰만 애니메이션 disable

하지만
- OnboardingFeature에서 서버통신에러뷰가 떴을 때, '홈으로 가기' 클릭 시 OnboardingView 재초기화 하면, width가 안잡히는 버그 잡기
-> 이것에 대해 삽질만 몇시간을 하다가 잠시 포기했습니다 ^0^

```swift
// '홈으로 가기' 클릭 시 Onboarding State를 다시 재 초기화 해주는 부분

    case .requestError(.presented(.moveToHome)):
      if state.onboarding != nil {
        state.onboarding = OnboardingCore.State()
      } else if state.home != nil {
        state.home = HomeCore.State()
      }
      return .none
```

```swift
// OnboardingView 에서 뷰 width를 가져오는 부분

    .setFrameMeasure(space: .global, identifier: backgroundFrame)
    .getFrameMeasure { value in
      /* TODO: 11.25
       Onboarding 재 초기화 시 FrameMeasure 관련 모디파이어를 안거침 . ,, 파악중
       getFrameMeasure -> OnDisappear 시에도 거치는 이유는 ?
      */
      guard let background = value[backgroundFrame] else { return }
      store.width = background.width
    }
```
> 이 부분을 안거침 -> width가 0으로 잡혀서 TabView와 관련된 것들이 모두 뜨지 않음 -> 근데 '시작하기' 버튼을 누르며 OnDisappear 시 잠깐 background.width가 잡혀서 아주 잠깐 TabView가 보이는 것을 목격

## 어떤 것을 작업하셨나요? 🛠
- 문의 url 수정
- 로딩뷰 분리

## 🌱 PR Point
- PR Point 1
- PR Point 2
